### PR TITLE
test/amg.c: include _hypre_parcsr_ls.h to fix build warning

### DIFF
--- a/test/amg.c
+++ b/test/amg.c
@@ -32,6 +32,7 @@
 
 #include "HYPRE_IJ_mv.h"
 #include "HYPRE_parcsr_ls.h"
+#include "_hypre_parcsr_ls.h"
 #include "_hypre_parcsr_mv.h"
 #include "HYPRE_krylov.h"
 


### PR DESCRIPTION
The missing declaration of HYPRE_BoomerAMGGetCumNnzAP is throwing a warning when building with gcc, fix this by including _hypre_parcsr_ls.h

amg.c: In function 'main':
amg.c:406:7: warning: implicit declaration of function 'HYPRE_BoomerAMGGetCumNnzAP'; did you mean 'HYPRE_BoomerAMGSetNumPaths'? [-Wimplicit-function-declaration]
  406 |       HYPRE_BoomerAMGGetCumNnzAP(pcg_precond, &cum_nnz_AP);
      |       ^~~~~~~~~~~~~~~~~~~~~~~~~~
      |       HYPRE_BoomerAMGSetNumPaths